### PR TITLE
Fixed trivial mispelling in Manpage

### DIFF
--- a/doc/rst2pdf.txt
+++ b/doc/rst2pdf.txt
@@ -101,7 +101,7 @@ The possible values are:
                     
                     
 --repeat-table-rows
-                    Repeats header row for each splitted table
+                    Repeats header row for each split table
 
 --raw-html          Support embeddig raw HTML. Default: False
 


### PR DESCRIPTION
One of the quality control tools used while packaging for debian reported this spelling mistake: I'm proposing this PR mostly to reduce its noise and because it was trivial enough to prepare (and — I hope — for you to accept or ignore).
